### PR TITLE
Gst::Buffer: Removed spurious semicolon

### DIFF
--- a/gstreamer/src/buffer.hg
+++ b/gstreamer/src/buffer.hg
@@ -196,7 +196,7 @@ public:
    * @param mem: a Gst::Memory.
    */
   void append_memory(Glib::RefPtr<Gst::Memory>& mem);
-  _IGNORE(gst_buffer_append_memory);
+  _IGNORE(gst_buffer_append_memory)
 
   _WRAP_METHOD(void remove_memory(guint idx), gst_buffer_remove_memory)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,7 +16,7 @@
 gstreamermm_includes = -I$(top_builddir)/gstreamer $(if $(srcdir:.=),-I$(top_srcdir)/gstreamer)
 local_libgstreamermm = $(top_builddir)/gstreamer/gstreamermm/libgstreamermm-$(GSTREAMERMM_API_VERSION).la
 
-AM_CPPFLAGS = -I$(top_builddir) $(gstreamermm_includes) $(GSTREAMERMM_CFLAGS) -std=c++0x -Wall -Werror -Wextra
+AM_CPPFLAGS = -I$(top_builddir) $(gstreamermm_includes) $(GSTREAMERMM_CFLAGS) -std=c++0x -Wall -Werror -Wextra -Wpedantic
 AM_CXXFLAGS = $(GSTREAMERMM_WXXFLAGS) -g
 LDADD = $(GSTREAMERMM_LIBS) $(local_libgstreamermm) -lgtest -lpthread
 


### PR DESCRIPTION
Removes a spurious semicolon, which problems with programs compiled with `-Werror -Wpedantic`
