### PR TITLE
Remove the trailing semicolon, to get rid of two semicolons in videoinfo.h

### DIFF
--- a/gstreamer/src/videoinfo.hg
+++ b/gstreamer/src/videoinfo.hg
@@ -66,7 +66,7 @@ public:
   _WRAP_METHOD(void init(), gst_video_info_init)
   _WRAP_METHOD(void set_format(Gst::VideoFormat format, guint width, guint height), gst_video_info_set_format)
   _WRAP_METHOD(bool from_caps(const Glib::RefPtr<const Gst::Caps>& caps), gst_video_info_from_caps)
-  _WRAP_METHOD(Glib::RefPtr<Gst::Caps> to_caps() const, gst_video_info_to_caps);
+  _WRAP_METHOD(Glib::RefPtr<Gst::Caps> to_caps() const, gst_video_info_to_caps)
   _WRAP_METHOD(bool convert(Gst::Format src_format, gint64 src_value, Gst::Format dest_format, gint64& dest_value), gst_video_info_convert)
   _WRAP_METHOD(bool is_equal(const Gst::VideoInfo& other) const, gst_video_info_is_equal)
 


### PR DESCRIPTION
The produced `videoinfo.h` contains the following line:

    Glib::RefPtr<Gst::Caps> to_caps() const;;

This is, because the file `videoinfo.hg` contains a semicolon in line 69. Remove it, and than the compiler doesn't complain about extra semicolons:

/usr/include/gstreamermm-1.0/gstreamermm/videoinfo.h:547:43: error: extra ‘;’ [-Wpedantic]
   Glib::RefPtr<Gst::Caps> to_caps() const;;

I'm using g++-8.1.0 and the debian testing package of gstreamermm (1.10.0).